### PR TITLE
Fixing spelling mistakes

### DIFF
--- a/planets/bop/peaks/crewReport.cfg
+++ b/planets/bop/peaks/crewReport.cfg
@@ -14,7 +14,7 @@
 		BopSrfLandedPeaks = I can see Kerbin from here! I wish I had a telescope...
 		BopSrfLandedPeaks = Mission Control tells you that the amazing vista you see is just an optical illusion. You take some picture anyway.
 		BopInSpaceLow = That mountain high enough to hit you. You hope you are landing.
-		BopInSpaceLow = Last time we went to Gilly, we didn not come back... oh? This is Bop?
+		BopInSpaceLow = Last time we went to Gilly, we did not come back... oh? This is Bop?
 		BopInSpaceHigh = Bop looks remarkably like a potato from this height. 
 		BopInSpaceHigh = Mission Control informs you that that no, that is not a potato outside your window.
 		BopInSpaceHigh = You realize that that mountain is remarkably high.

--- a/planets/duna/poles/gravityScan.cfg
+++ b/planets/duna/poles/gravityScan.cfg
@@ -10,7 +10,7 @@
 		//DunaSrfLandedPoles = Your science report text here.
 		//DunaInSpaceLowPoles = Your science report text here.
 		//DunaInSpaceHighPoles = Your science report text here.
-		DunaSrfLandedPoles = Picking up a kerbin-sized hunk of ice is easy. If you entered a strongkerbal contest remotely, you would win gold!
+		DunaSrfLandedPoles = Picking up a Kerbin-sized hunk of ice is easy. If you entered a strongkerbal contest remotely, you would win gold!
 		DunaInSpaceLowPoles = There doesn't seem to be any gravity here. You grab a towel that is floating by and stow it away.
 		DunaInSpaceHighPoles = Doing a cartwheel takes no effort. You accidentally hit a switch while spinning, hopefully it didn't do anything.
 		//LAST_ENTRY

--- a/planets/eve/lowlands/barometerScan.cfg
+++ b/planets/eve/lowlands/barometerScan.cfg
@@ -11,9 +11,9 @@
 		//EveFlyingLow = Your science report text here.
 		//EveFlyingHigh = Your science report text here.
 		  EveSrfLandedLowlands = You start laughing at the abnormally high reading as you realize you're going to be stuck here for a long time.
-		  EveSrfLandedLowlands = You calculate the amount of DeltaV just to escape the atmosphere is greater than that it took to both escape Kerbin's and get here!
+		  EveSrfLandedLowlands = You calculate the amount of Delta-V just to escape the atmosphere is greater than that it took to both escape Kerbin's and get here!
 		  EveSrfLandedLowlands = You tap the glass of the barometer. Nope, it's not broken.
-		  EveSrfLandedLowlands = It's over 9000...m/s! Well, the DeltaV required to escape the atmosphere anyways.
+		  EveSrfLandedLowlands = It's over 9000...m/s! Well, the Delta-V required to escape the atmosphere anyways.
 		  EveFlyingLow = You secretly wish your friends and family the best as landing here may be the last landing you'll ever make. 
 
   		//LAST_ENTRY

--- a/planets/kerbin/badlands/atmosphereAnalysis.cfg
+++ b/planets/kerbin/badlands/atmosphereAnalysis.cfg
@@ -14,7 +14,7 @@
 		KerbinSrfLandedBadlands = The sensor complains about a mosquito divebombing it. Apparently it's carrying malaria.
 		KerbinSrfLandedBadlands = It's not so bad here. You wonder what all the fuss was about.
 		KerbinSrfLandedBadlands = The Gooey puddle you just stepped in appears to be eating through the material of your spacesuit. Better get back to the ship before the atmosphere outside is the same as inside your spacesuit.
-		KerbinFlyingLowBadlands = The sensor records a sufurous rotten egg smell in the atmosphere.  So this is why they call it the Badlands.
+		KerbinFlyingLowBadlands = The sensor records a sulfurous rotten egg smell in the atmosphere.  So this is why they call it the Badlands.
 		KerbinFlyingLowBadlands = Atmospheric analysis of the surrounding air makes you very glad that you brought your spacesuit.
 		KerbinFlyingLowBadlands = Upon examining the sensor's readouts, you firmly decide against cracking open a window.
 		KerbinFlyingHighBadlands = Analysis of the Badlands' atmosphere makes it difficult to believe that you're still on Kerbin.

--- a/planets/kerbin/badlands/mobileMaterialsLab.cfg
+++ b/planets/kerbin/badlands/mobileMaterialsLab.cfg
@@ -22,7 +22,7 @@
 		KerbinFlyingHigh = As you expose the samples to the Badlands' atmosphere, you force yourself to accept the fact that they will never be the same again.
 		KerbinFlyingHigh = Even at this altitude, none of your samples are spared from the horror that is the Badlands.
 		KerbinInSpaceLow = You quickly slam the door shut on the lab after peeking in.  It doesn't look good in there, to say the least.
-		KerbinInSpaceLow = The samples don't appear to be bothered too much by the fact thaat they're over the Badlands. Perhaps its influence is limited to within the atmosphere?
+		KerbinInSpaceLow = The samples don't appear to be bothered too much by the fact that they're over the Badlands. Perhaps its influence is limited to within the atmosphere?
 		KerbinInSpaceLow = The samples barely react other than giving a small shudder.
 		KerbinInSpaceHigh = You consider how nice it is to be in the lab rather than in the Badlands below you.
 		KerbinInSpaceHigh = The materials bay seems cautiously optimistic about being this far away from the Badlands.

--- a/planets/kerbin/badlands/mysteryGoo.cfg
+++ b/planets/kerbin/badlands/mysteryGoo.cfg
@@ -22,7 +22,7 @@
 		KerbinFlyingHigh = The Mystery Goo becomes depressed as you fly over the Badlands. You want to give it a comforting hug then remember why it's a bad idea. 
 		KerbinInSpaceLow = The Goo looks particularly dark and brooding here.
 		KerbinInSpaceLow = The Mystery Goo radiates menace as you pass over the Badlands.
-		KerbinInSpaceHigh = Mystery Goo and Badlands seem like a bad combination to you. Rather than opening a pandoras box, you forego the experiment and make up some data to send back to KSC.
+		KerbinInSpaceHigh = Mystery Goo and Badlands seem like a bad combination to you. Rather than opening a Pandora's box, you forego the experiment and make up some data to send back to KSC.
 		KerbinInSpaceHigh = Dispersing Mystery Goo in space high above the Badlands is not your idea of a good work safety practice.
 		//LAST_ENTRY
 	}

--- a/planets/kerbin/badlands/temperatureScan.cfg
+++ b/planets/kerbin/badlands/temperatureScan.cfg
@@ -16,7 +16,7 @@
 		KerbinSrfLandedBadlands = Man the EVA is gonna suck.
 		KerbinFlyingLowBadlands = It is HOT! You don't know whether it's the normal ambient temperature here or whether the spacecraft is burning up.  Either way, we should have installed air conditioning.
 		KerbinFlyingLowBadlands = You pour the remains of your juice pack over the engines in a frantic attempt to keep them from overheating.
-		KerbinFlyingHigh = Let's see...temperature. Slightly cooler than the firey pits of hell. Yep, that covers it.
+		KerbinFlyingHigh = Let's see...temperature. Slightly cooler than the fiery pits of hell. Yep, that covers it.
 		KerbinFlyingHigh = Mission Control declares that they can't distinguish your craft from the background ambient temperature. This is a problem since your engines are currently firing...
 		KerbinInSpaceLow = Seriously? You want to know the temperature now? We're in space; who cares!
 		KerbinInSpaceLow = The hellish climate of the Badlands can't touch you up here!

--- a/planets/kerbin/default/evaReport.cfg
+++ b/planets/kerbin/default/evaReport.cfg
@@ -30,13 +30,13 @@
 		KerbinSrfSplashed = As the water rushes to your face, you begin to thrash and wail and gasp, and then remember your suit is airtight.
 		KerbinSrfSplashed = What are those creatures circling below?
 		KerbinSrfSplashed = Now I really wish I knew how to swim!
-		KerbinFlyingLow = I'm free! Freefalling.
+		KerbinFlyingLow = I'm free! Free falling.
 		KerbinFlyingLow = Flying this close to the ground is definitely not over-rated!
 		KerbinFlyingLow = Get back in! Quick!
 		KerbinFlyingLow = The ground is looking awful close. Did you pack a parachute?
 		KerbinFlyingLow = This isn't that high up after all...
 		KerbinFlyingLow = I wonder if I can buzz the tower while hanging off the side of the cockpit...
-		KerbinFlyingHigh = You might be ok for a few minutes.
+		KerbinFlyingHigh = You might be OK for a few minutes.
 		KerbinFlyingHigh = The clouds look so pretty from up here.
 		KerbinFlyingHigh = Did you remember to pack a parachute?
 		KerbinInSpaceLow = You've successfully played hide and seek with Mission Control. Crap.

--- a/planets/kerbin/default/gravityScan.cfg
+++ b/planets/kerbin/default/gravityScan.cfg
@@ -12,7 +12,7 @@
 		//KerbinInSpaceLow = Your science report text here.
 		//KerbinInSpaceHigh = Your science report text here.
 		
-		KerbinSrfLanded = Huh, the gravity here is exactly the same as at Jebs house.  Who'd have guessed.
+		KerbinSrfLanded = Huh, the gravity here is exactly the same as at Jeb's house.  Who'd have guessed.
 		KerbinSrfSplashed = The instrument starts sparking and shorts out before you can take a reading.
 		KerbinInSpaceLow = For some reason, the planet seems to be pulling you in. What a surprise!
 		KerbinInSpaceHigh = The gravity seems to be incredibly high for a celestial body of this size. It must be composed of an extremely dense material.

--- a/planets/kerbin/deserts/atmosphereAnalysis.cfg
+++ b/planets/kerbin/deserts/atmosphereAnalysis.cfg
@@ -16,7 +16,7 @@
 		KerbinSrfLandedDeserts = This can't be right, the sensor is detecting the atmosphere as solid! Oh wait, it's just dust-clogged again.  
 		KerbinFlyingLowDeserts = You find that the air is much drier over the desert.
 		KerbinFlyingLowDeserts = Very little signs of precipitation. No wonder the place looks so thirsty.
-		KerbinFlyingHighDeserts = The sensor reads 0 humidity.  In fact it looks like the needle is bent as the guage tries to register negative numbers.
+		KerbinFlyingHighDeserts = The sensor reads 0 humidity.  In fact it looks like the needle is bent as the gauge tries to register negative numbers.
 		KerbinFlyingHighDeserts = The humidity readings make you want to take off your spacesuit and lather yourself in lotion.
 		//LAST_ENTRY
 	}

--- a/planets/kerbin/deserts/gravityScan.cfg
+++ b/planets/kerbin/deserts/gravityScan.cfg
@@ -11,10 +11,10 @@
 		//KerbinInSpaceLowDeserts = Your science report text here.
 		//KerbinInSpaceHighDeserts = Your science report text here.
 
-		KerbinSrfLandedDeserts = You look around at some dried bones scattered on the ground, and feel the tug of Kerbins' gravitational field pulling you to the earth.  Or maybe that is just your imagination.  Time for some snacks! 
+		KerbinSrfLandedDeserts = You look around at some dried bones scattered on the ground, and feel the tug of Kerbin's' gravitational field pulling you to the earth.  Or maybe that is just your imagination.  Time for some snacks! 
 		KerbinSrfLandedDeserts = You splash juice over the gravity scanner. It was probably pretty thirsty.
 		KerbinInSpaceLowDeserts = The dunes appear to have a stable gravity, though some spikes indicate the underground terrain varies in composition.
-		KerbinInSpaceLowDeserts = Gravitational data from orbit reveals an incredibly complex network of subterrenean formations beneath the deserts of Kerbin.
+		KerbinInSpaceLowDeserts = Gravitational data from orbit reveals an incredibly complex network of subterranean formations beneath the deserts of Kerbin.
 		KerbinInSpaceHighDeserts = Orbital gravity scans make the deserts far more interesting than they appear to be to the naked eye.
 		KerbinInSpaceHighDeserts = The graviolis here seem dry and dusty like the surface below.  You consider offering them a glass of water, but have no idea how to speak gravioli.
 		//LAST_ENTRY

--- a/planets/kerbin/deserts/gravityScan.cfg
+++ b/planets/kerbin/deserts/gravityScan.cfg
@@ -11,7 +11,7 @@
 		//KerbinInSpaceLowDeserts = Your science report text here.
 		//KerbinInSpaceHighDeserts = Your science report text here.
 
-		KerbinSrfLandedDeserts = You look around at some dried bones scattered on the ground, and feel the tug of Kerbin's' gravitational field pulling you to the earth.  Or maybe that is just your imagination.  Time for some snacks! 
+		KerbinSrfLandedDeserts = You look around at some dried bones scattered on the ground, and feel the tug of Kerbin's gravitational field pulling you to the earth.  Or maybe that is just your imagination.  Time for some snacks! 
 		KerbinSrfLandedDeserts = You splash juice over the gravity scanner. It was probably pretty thirsty.
 		KerbinInSpaceLowDeserts = The dunes appear to have a stable gravity, though some spikes indicate the underground terrain varies in composition.
 		KerbinInSpaceLowDeserts = Gravitational data from orbit reveals an incredibly complex network of subterranean formations beneath the deserts of Kerbin.

--- a/planets/kerbin/deserts/temperatureScan.cfg
+++ b/planets/kerbin/deserts/temperatureScan.cfg
@@ -16,7 +16,7 @@
 		KerbinSrfLandedDeserts = Large plumes of heat are rising from the surface of the desert.
 		KerbinSrfLandedDeserts = The temperature here is very hot.
 		KerbinSrfLandedDeserts = The thermometer quickly rises beyond the scale limit. You put it back into the shadows before it bursts.
-		KerbinFlyingLowDeserts = Even here above the surface it is hot.  The thermometer reads 270 degrees. You wonder if that is in Celsius, Farenheit, or Kelvin.  Oh well, the scientist back at KSC will figure it out.
+		KerbinFlyingLowDeserts = Even here above the surface it is hot.  The thermometer reads 270 degrees. You wonder if that is in Celsius, Fahrenheit, or Kelvin.  Oh well, the scientist back at KSC will figure it out.
 		KerbinFlyingLowDeserts = Your temperature readings over the desert surprise exactly nobody back at KSC.
 		KerbinFlyingHigh = The thermometer is hanging on to the capsule by only one corner, and you are afraid if you touch it it will go flying off.  We should have used the super-glue instead of the ok-glue.
 		KerbinFlyingHigh = You resist the urge to place your craft into a steep dive just to see how fast the thermometer changes.

--- a/planets/kerbin/grasslands/atmosphereAnalysis.cfg
+++ b/planets/kerbin/grasslands/atmosphereAnalysis.cfg
@@ -15,7 +15,7 @@
 		KerbinSrfLandedGrasslands = You decide to do one better and smell the air yourself. Ah, smells like home.
 		KerbinFlyingLowGrasslands = The atmosphere seems calm and peaceful here. Readings are nominal.
 		KerbinFlyingLowGrasslands = Ah so this is what a life-supporting atmosphere is supposed to look like.
-		KerbinFlyingHighGrasslands = As you read the atmosperic analysis report you glance down at the surface below. The gentle undulating motion of the breeze through the grass makes you feel sleepy.
+		KerbinFlyingHighGrasslands = As you read the atmospheric analysis report you glance down at the surface below. The gentle undulating motion of the breeze through the grass makes you feel sleepy.
 		KerbinFlyingHighGrasslands = You let the atmospheric sensor do its thing. You don't anticipate any earth-shaking discoveries.
 		//LAST_ENTRY
 	}

--- a/planets/kerbin/grasslands/gravityScan.cfg
+++ b/planets/kerbin/grasslands/gravityScan.cfg
@@ -16,7 +16,7 @@
 		KerbinInSpaceLowGrasslands = You happily munch on a snack while performing a gravity scan over the Grasslands.
 		KerbinInSpaceLowGrasslands = A scientist at KSC once told you that without gravity, the grass would grow into outer space! On second thought, he probably wasn't a real scientist.
 		KerbinInSpaceLowGrasslands = The instrument surveys the gravity over the Grasslands. It appears the field is very stable here.
-		KerbinInSpaceHighGrasslands = Gravity scans over the Grasslands are normal...too normal. You begin to suspect that the gras is hiding something.
+		KerbinInSpaceHighGrasslands = Gravity scans over the Grasslands are normal...too normal. You begin to suspect that the grass is hiding something.
 		KerbinInSpaceHighGrasslands = As you fly high over the Grasslands you can feel the graviolis swarming around you. They seem excited.
 		//LAST_ENTRY
 	}

--- a/planets/kerbin/highlands/barometerScan.cfg
+++ b/planets/kerbin/highlands/barometerScan.cfg
@@ -12,7 +12,7 @@
 		//KerbinFlyingHigh = Your science report text here.
 
 		KerbinSrfLandedHighlands = You make adjustments to the barometer to get an accurate reading at such a high altitude.  Hopefully they appreciate your work back at KSC.
-		KerbinSrfLandedHighlands = Barometer data indicates higher-than-normal humidity and precipitaion. You guess that's just what happens when you're closer to the sky. 
+		KerbinSrfLandedHighlands = Barometer data indicates higher-than-normal humidity and precipitation. You guess that's just what happens when you're closer to the sky. 
 		KerbinFlyingLow = *singing* "Under pressure. Ba da dum, ba da da dum, Ba da da dum, ba da da dum. Under pressure".
 		KerbinFlyingLow = Pressure readings are more or less in line with the rest of Kerbin. Much unlike the Highlands themselves.
 		KerbinFlyingHigh = The barometer is covered in ice crystals at this altitude, and you are unable to get a good reading.  Oh well, time for some snacks anyway.

--- a/planets/kerbin/highlands/evaReport.cfg
+++ b/planets/kerbin/highlands/evaReport.cfg
@@ -17,7 +17,7 @@
 		KerbinSrfLandedHighlands = The hills are steep and the weather is miserable. No wonder people from the Highlands are always so cranky.
 		KerbinFlyingLowHighlands = You are afraid that your helmet will hit the peak of one of the mountains as you fly by.  Who thought an EVA was a good idea here, anyway.
 		KerbinFlyingLowHighlands = You're pretty sure you can reach out and grab a surface sample from the top of one of these hills.
-		KerbinFlyingHigh = You hold on for dear life as you hurtle through the atmosphere above some of Kerbins highest mountains.  Too much adrenaline.
+		KerbinFlyingHigh = You hold on for dear life as you hurtle through the atmosphere above some of Kerbin's highest mountains.  Too much adrenaline.
 		KerbinFlyingHigh = Yep, those are the Highlands. Can I go back in now?
 		KerbinInSpaceLowHighlands = Yup, that's a mountain down there.  What's of greater concern is the mountain of snacks that need to be eaten *nom, nom, nom*.
 		KerbinInSpaceLowHighlands = The Highlands are baby mountains. You wonder if you'll ever get to see them grow up.

--- a/planets/kerbin/ksc/atmosphereAnalysis.cfg
+++ b/planets/kerbin/ksc/atmosphereAnalysis.cfg
@@ -15,7 +15,7 @@
 		KerbinSrfLandedKSC = A surprising amount of paint and ink volatiles, combined with ozone from welding and short circuits. About what you'd expect from a thriving space program.
 		KerbinSrfLandedAstronautComplex = The sensor picks up fear and excitement in the atmosphere.  Don't ask how.
 		KerbinSrfLandedMissionControl = The atmosphere is always tense here.  You didn't need a sensor to figure that out.
-		KerbinSrfLandedRunway = Atmosperic conditions look good for takeoff. Punch it!
+		KerbinSrfLandedRunway = Atmospheric conditions look good for takeoff. Punch it!
 		KerbinSrfLandedSPH = The sensor registers a cool breeze coming from the spaceplane hangar.  We always knew this was a cool place.
 		KerbinSrfLandedSPHMainBuilding = The atmosphere here is pure awesomesauce.  Really.  It doesn't get much better. 
 		KerbinSrfLandedSPHRoundTank = The sensor notes the slight venturi effect of the wind whipping around the SPH tank.
@@ -47,7 +47,7 @@
 		KerbinSrfLandedRunway = Wind speed changes slightly as a small insect passes in front of the sensor.
 		KerbinSrfLandedRunway = Readings suggest today is as good a time for flying as any.
 		KerbinSrfLandedFlagPole = You install the sensor on top of the flag pole.
-		KerbinSrfLandedFlagPole = The sensor tells you thet the flag is working as advertised.
+		KerbinSrfLandedFlagPole = The sensor tells you that the flag is working as advertised.
 		KerbinSrfLandedAdministration = The atmosphere heats up as Montimer learns about how our funds have been spend lately.
 		KerbinSrfLandedCrawlerway = It's surprisingly windy out in the open.
 		KerbinFlyingLowKSC = Atmosphere analysis??? Let's worry about flying this thing first!

--- a/planets/kerbin/ksc/barometerScan.cfg
+++ b/planets/kerbin/ksc/barometerScan.cfg
@@ -38,12 +38,12 @@
 		KerbinSrfLandedVABRoundTank = The barometer detects a small leak. You consider informing Gus Kerman but refrain from it, realizing that he probably doesn't care.
 		KerbinSrfLandedVABTanks = The barometer detects a small leak. You consider informing Gus Kerman but refrain from it, realizing that he probably doesn't care. 
 		KerbinSrfLandedR&D = As you attempt to record your observation, one of the research scientists comes over to explain that a millibar is not where those little umbrellas that come in drinks come from.
-		KerbinSrfLandedR&DCentralBuilding = The folks at R&D diassemble your barometer before you have a chance to take a reading.  What did you expect?
-		KerbinSrfLandedR&DCornerLab = You hope to get a reading before your instrument is diassembled for parts by the staff here, by hiding in this corner. 
-		KerbinSrfLandedR&DMainBuilding = You point at an imaginary flying purple elephant to distract the staff here from diassembling your instrument just long enough to get a reading.
+		KerbinSrfLandedR&DCentralBuilding = The folks at R&D disassemble your barometer before you have a chance to take a reading.  What did you expect?
+		KerbinSrfLandedR&DCornerLab = You hope to get a reading before your instrument is disassembled for parts by the staff here, by hiding in this corner. 
+		KerbinSrfLandedR&DMainBuilding = You point at an imaginary flying purple elephant to distract the staff here from disassembling your instrument just long enough to get a reading.
 		KerbinSrfLandedR&DObservatory = How fitting to take your barometric pressure observation here.  Must have been fate.
-		KerbinSrfLandedR&DSideLab = Ok, how many labs are there here??  You're tired of barometric pressures, and just want some snacks. 
-		KerbinSrfLandedR&DSmallLab = The smallness of the lab constrict the atmosphere, causing a highter reading.
+		KerbinSrfLandedR&DSideLab = OK, how many labs are there here??  You're tired of barometric pressures, and just want some snacks. 
+		KerbinSrfLandedR&DSmallLab = The smallness of the lab constrict the atmosphere, causing a higher reading.
 		KerbinSrfLandedR&DTanks = You get distracted listening to your voice echo in the tanks and forget to take a barometric reading.
 		KerbinSrfLandedR&DWindTunnel =  The barometer blows away before you are able to record the results.  Oh well, it was worth a try.
 		KerbinFlyingLow = Despite the fact that you are flying low over the surface, the reading is no lower than usual.

--- a/planets/kerbin/ksc/crewReport.cfg
+++ b/planets/kerbin/ksc/crewReport.cfg
@@ -23,7 +23,7 @@
 		KerbinSrfLandedKSC = You should probably climb the VAB! 
 		KerbinSrfLandedAdministration = You watch Montimer swing a golf ball into the pond. 
 		KerbinSrfLandedAstronautComplex = You are just happy that we didn't land on any of the new recruits.
-		KerbinSrfLandedCrawlerway = You Pretend to be the Crawler driver. After a Few minutes you realize that you'd rather fly to space. 
+		KerbinSrfLandedCrawlerway = You pretend to be the Crawler driver. After a few minutes you realize that you'd rather fly to space. 
 		KerbinSrfLandedFlagPole = You wonder if this will be the site of your grave marker. 
 		KerbinSrfLandedLaunchPad = You look up at the stars and begin to count. You realize you should take off before you fall asleep.
 		KerbinSrfLandedLaunchPad = You regret wearing a red shirt to work today.

--- a/planets/kerbin/ksc/crewReport.cfg
+++ b/planets/kerbin/ksc/crewReport.cfg
@@ -63,7 +63,7 @@
 		KerbinSrfLandedRunway = This runway needs a ramp.
 		KerbinSrfLandedSPH = You hope they can still roll the planes out, having landed this close to the SPH.
 		KerbinSrfLandedSPHMainBuilding = Whew, that was a close one, we almost hit the SPH!
-		KerbinSrfLandedSPHRoundTank = You notice that your ship looks starangely similar to the tanks over there.
+		KerbinSrfLandedSPHRoundTank = You notice that your ship looks strangely similar to the tanks over there.
 		KerbinSrfLandedSPHTanks = You feel inadequate in your little ship surrounded by all these huge tanks.
 		KerbinSrfLandedSPHWaterTower = You consider jumping out of the spacecraft and climbing the water tower.
 		KerbinSrfLandedTrackingStation = You sure hope they can track you from here.

--- a/planets/kerbin/ksc/crewReport.cfg
+++ b/planets/kerbin/ksc/crewReport.cfg
@@ -23,7 +23,7 @@
 		KerbinSrfLandedKSC = You should probably climb the VAB! 
 		KerbinSrfLandedAdministration = You watch Montimer swing a golf ball into the pond. 
 		KerbinSrfLandedAstronautComplex = You are just happy that we didn't land on any of the new recruits.
-		KerbinSrfLandedCrawlerway = You Pretend to be the Crawler driver. After a Few minutes you realize that you'd rater fly to space. 
+		KerbinSrfLandedCrawlerway = You Pretend to be the Crawler driver. After a Few minutes you realize that you'd rather fly to space. 
 		KerbinSrfLandedFlagPole = You wonder if this will be the site of your grave marker. 
 		KerbinSrfLandedLaunchPad = You look up at the stars and begin to count. You realize you should take off before you fall asleep.
 		KerbinSrfLandedLaunchPad = You regret wearing a red shirt to work today.

--- a/planets/kerbin/ksc/evaReport.cfg
+++ b/planets/kerbin/ksc/evaReport.cfg
@@ -25,7 +25,7 @@
 		KerbinSrfLandedAdministration = You wonder what the briefing will be about.
 		KerbinSrfLandedAstronautComplex = KSC tour stop number 2 of 31: Welcome to the Astronaut Complex.
 		KerbinSrfLandedCrawlerway = KSC tour stop number 3 of 31: Welcome to the Crawlerway.
-		KerbinSrfLandedCrawlerway = You wonder if you can repurpose the Crawlerway and the LaunchPad as a horizontal launcher with a ramp. What could go wrong?
+		KerbinSrfLandedCrawlerway = You wonder if you can repurpose the Crawlerway and the Launchpad as a horizontal launcher with a ramp. What could go wrong?
 		KerbinSrfLandedCrawlerway = You imagine being the driver of the crawler. It must be the second best job on Kerbin.
 		KerbinSrfLandedFlagPole = KSC tour stop number 4 of 31: Welcome to the Flag Pole.
 		KerbinSrfLandedFlagPole = You stumble as you try to get to the base of the pole.
@@ -37,7 +37,7 @@
 		KerbinSrfLandedLaunchPad = You feel compelled to stare at the sky.
 		KerbinSrfLandedLaunchPad = We don't seem to have gone very far... yet.
 		KerbinSrfLandedMissionControl = KSC tour stop number 6 of 31: Welcome to Mission Control.
-		KerbinSrfLandedMissionControl = You hear Gene Kerman barking "FAILIURE is NOT an OPTION!"
+		KerbinSrfLandedMissionControl = You hear Gene Kerman barking "FAILURE is NOT an OPTION!"
 		KerbinSrfLandedMissionControl = You join Walt Kerman in cleaning up the Visitors Lounge for the next launch.
 		KerbinSrfLandedMissionControl = You join Walt Kerman in cleaning up the Visitors Lounge from the latest launch mishap.
 		KerbinSrfLandedRunway = KSC tour stop number 7 of 31: Welcome to the Runway.
@@ -67,7 +67,7 @@
 		KerbinSrfLandedR&DWindTunnel = KSC tour stop number 31 of 31: Welcome to the R&D Wind Tunnel.  You made it to the last stop! Congratulations!
 		KerbinFlyingLowKSC = You are really just showboating for the guys at KSC, but isn't that what huge rockets are for??
 		KerbinFlyingHigh = You wonder if the guys back at KSC can see you out the window, and not just on their comms display. You wave just in case.
-		KerbinInSpaceLowKSC = You can just make out the Vab and launchpad from here.  What a sight.
+		KerbinInSpaceLowKSC = You can just make out the VAB and launchpad from here.  What a sight.
 		KerbinInSpaceHigh = You wonder if you dropped a rock from here at just the right place, if it would land at KSC.
 		//LAST_ENTRY
 	}

--- a/planets/kerbin/ksc/gravityScan.cfg
+++ b/planets/kerbin/ksc/gravityScan.cfg
@@ -12,13 +12,13 @@
 		//KerbinInSpaceLowKSC = Your science report text here.
 		//KerbinInSpaceHighKSC = Your science report text here.
 		KerbinSrfLandedKSC = The scanner indicates that gravity does, in fact, exist.
-		KerbinSrfLandedAdministration = The grviolis try to look professional. It's not really working.
+		KerbinSrfLandedAdministration = The graviolis try to look professional. It's not really working.
 		KerbinSrfLandedAstronautComplex = The new recruits crowd around to check out your awesome sensor.
 		KerbinSrfLandedCrawlerway = You measure the gravity slightly increasing as the crawler goes by.
 		KerbinSrfLandedFlagPole = Being on top of the pole you realize the gravity of the situation. 
 		KerbinSrfLandedLaunchPad =  The sensor gets burned to a crisp from the rocket exhaust, and is useless now. 
 		KerbinSrfLandedMissionControl = The operators here think that the universe revolves around them, but your gravity readings indicate otherwise.
-		KerbinSrfLandedRunway =  You are too busy dodging taxi-ing planes to get an accurate reading. 
+		KerbinSrfLandedRunway =  You are too busy dodging taxiing planes to get an accurate reading. 
 		KerbinSrfLandedSPH = The gravity here seems normal.  Snacktime!!
 		KerbinSrfLandedSPHMainBuilding = Despite the ongoing debate, the gravity here seems the same as at the VAB.
 		KerbinSrfLandedSPHRoundTank = The graviolis seem too busy doing circles in the tank to pay attention to the task at hand.  
@@ -43,7 +43,7 @@
 		KerbinSrfLandedR&DSmallLab = The graviolis feel cramped in here, and register a higher reading than normal.
 		KerbinSrfLandedR&DTanks = The graviolis seem confused with all the tanks around.  We should try this experiment somewhere else.
 		KerbinSrfLandedR&DWindTunnel =  The instrument gets blown away and rolls down the tarmac before you can take an accurate reading. 
-		KerbinInSpaceLowKSC = The graviolis appear happy to finally be escaping Kerbins gravitational well.
+		KerbinInSpaceLowKSC = The graviolis appear happy to finally be escaping Kerbin's gravitational well.
 		KerbinInSpaceHighKSC = The graviolis look concerned that they may not be able to interact much at this altitude.	
 		//LAST_ENTRY
 	}

--- a/planets/kerbin/ksc/mysteryGoo.cfg
+++ b/planets/kerbin/ksc/mysteryGoo.cfg
@@ -57,7 +57,7 @@
 		KerbinSrfLandedR&DObservatory = The Goo observes you observing it.  Eerie.
 		KerbinSrfLandedR&DSideLab = The good sloshes to the side of its container in honor of the research that has been performed here in the past.
 		KerbinSrfLandedR&DSmallLab = The Goo looks cramped here, like it needs to stretch its...uhhhh...self. Yeah, that's it: stretch itself. 
-		KerbinSrfLandedR&DTanks = The Goo promply begins determining its compatibility with the substance in the tanks.
+		KerbinSrfLandedR&DTanks = The Goo promptly begins determining its compatibility with the substance in the tanks.
 		KerbinSrfLandedR&DWindTunnel = The Goo is promptly splattered against the wall as you open the container.  What did you expect, it's a wind tunnel!
 		KerbinFlyingLow = The Goo hangs on for dear life.
 		KerbinFlyingHigh = The Goo airs itself out in the cool breeze of the upper atmosphere.

--- a/planets/kerbin/ksc/surfaceSample.cfg
+++ b/planets/kerbin/ksc/surfaceSample.cfg
@@ -19,13 +19,13 @@
 		KerbinSrfLandedAdministration = Your contract prohibits you from taking a sample here. 
 		KerbinSrfLandedAstronautComplex = The toilet seems to be the cleanest room in the complex. 
 		KerbinSrfLandedCrawlerway = The surface seems compressed by the immense weight of the crawler passing by. 
-		KerbinSrfLandedFlagPole = Realizing that this is a place of rememberance you refrain from taking a sample. 
+		KerbinSrfLandedFlagPole = Realizing that this is a place of remembrance you refrain from taking a sample. 
 		KerbinSrfLandedLaunchPad = The surface is charred and coated with burnt rocket propellant. There are also trace amounts of a conspicuous green substance.
 		KerbinSrfLandedLaunchPad = Is that an engine bell?
 		KerbinSrfLandedLaunchPad = You attempt to pry off a sample, but Mission Control yells at you.
 		KerbinSrfLandedLaunchPad = Don't we already know what this is made out of?
 		KerbinSrfLandedLaunchPad = You pull off a loose bit of the grated metallic substance. As you stuff it in the sample bag, a couple engineers eye you angrily.
-		KerbinSrfLandedLaunchPad = The grated area is metalic, and the concrete is very... concrete-like. The staff advise you not to remove any section of the well-engineered launchpad, because it is expensive.
+		KerbinSrfLandedLaunchPad = The grated area is metallic, and the concrete is very... concrete-like. The staff advise you not to remove any section of the well-engineered launchpad, because it is expensive.
 		KerbinSrfLandedLaunchPad = Unable to sample the concrete, you pick up a quarter instead.
 		KerbinSrfLandedLaunchPad = You find a small puddle of rocket fuel where the last rocket was. Oops...
 		KerbinSrfLandedLaunchPad = You attempt to dig up a sample before you realizing that you are trying to dig up concrete with a shovel. You play it cool and hope no one notices.
@@ -47,7 +47,7 @@
 		KerbinSrfLandedSPHWaterTower =  The soil here is more moist than usual. 
 		KerbinSrfLandedTrackingStation = The soil here is completely uninteresting.
 		KerbinSrfLandedTrackingStationDishEast = Yep, nothing to report about this sample.  As expected.
-		KerbinSrfLandedTrackingStationDishNorth = You contemplate wether it is even worth taking this sample.
+		KerbinSrfLandedTrackingStationDishNorth = You contemplate whether it is even worth taking this sample.
 		KerbinSrfLandedTrackingStationDishSouth = You step in dog poop while taking the sample.  Lucky you.
 		KerbinSrfLandedTrackingStationHub = This whole area is entirely uninteresting.  As expected, the surface sample from here is as well.
 		KerbinSrfLandedVAB = The sample is 80% rocket fuel and 20% dirt.  Good thing there is no EPA here.

--- a/planets/kerbin/ksc/temperatureScan.cfg
+++ b/planets/kerbin/ksc/temperatureScan.cfg
@@ -15,12 +15,12 @@
 		
 		KerbinSrfLandedKSC = The temperature rises as an angry Gene Kerman comes over the radio and demands to know what you're still doing there. 
 		KerbinSrfLandedAdministration = The temperature drops. Montimer seems pleased with our spending of funds. 
-		KerbinSrfLandedAstronautComplex = The temperature here is elevated, but it's probably just due to the new recruits excitment to meet a real astronaut.
+		KerbinSrfLandedAstronautComplex = The temperature here is elevated, but it's probably just due to the new recruits excitement to meet a real astronaut.
 		KerbinSrfLandedCrawlerway = The thermometer gets crushed under the wheels of the crawler.  Oh well, time for some snacks.
 		KerbinSrfLandedFlagPole = You realize that the temperature drops the higher you climb the pole. 
 		KerbinSrfLandedLaunchPad = The temperature reading spikes suddenly. Did somebody start the engines? 
 		KerbinSrfLandedMissionControl = The temperature here is elevated from the tense atmosphere.
-		KerbinSrfLandedRunway = The jet exhause skews the temperature reading, and you have to throw out the results.
+		KerbinSrfLandedRunway = The jet exhaust skews the temperature reading, and you have to throw out the results.
 		KerbinSrfLandedSPH = The temperature here is cool due to the breeze blowing through the SPH.
 		KerbinSrfLandedSPHMainBuilding = You are unable to concentrate on taking a reading with the screaming of jet engines in the background.
 		KerbinSrfLandedSPHRoundTank = Seconds after being attached, the thermometer has frozen into place. 
@@ -28,7 +28,7 @@
 		KerbinSrfLandedSPHWaterTower = 3.983°C - You realize there is as much water in this tower as can be. 
 		KerbinSrfLandedTrackingStation =  Temperature here is: bored. Oops, that's just you.  The temperature is nominal. 
 		KerbinSrfLandedTrackingStationDishEast = You position the thermometer in the direct center of the dish hoping for an exciting result.  You are disappointed as usual.
-		KerbinSrfLandedTrackingStationDishNorth = In your boredome you drop the thermometer and break it.  No loss, it's not like there was anything worth reporting here anyway.
+		KerbinSrfLandedTrackingStationDishNorth = In your boredom you drop the thermometer and break it.  No loss, it's not like there was anything worth reporting here anyway.
 		KerbinSrfLandedTrackingStationDishSouth = You wait in anguish for yet another temperature reading.  What's the point?
 		KerbinSrfLandedTrackingStationHub = You explain the use of real scientific instruments like the thermometer to the staff at the tracking station.
 		KerbinSrfLandedVAB =  The ground spontaneously combusts from years of rocket fuel soaking into it, and the temperature spikes. 
@@ -39,7 +39,7 @@
 		KerbinSrfLandedR&D = The temperature here fluctuates wildly.
 		KerbinSrfLandedR&DCentralBuilding = The thermometer is sucked into a wormhole by an advanced project here.  You decide to write it off.
 		KerbinSrfLandedR&DCornerLab = You hide the thermometer in the corner hoping no-one will find it.
-		KerbinSrfLandedR&DMainBuilding = The R&D personnel dissasemble your thermometer before you can take a reading.
+		KerbinSrfLandedR&DMainBuilding = The R&D personnel disassemble your thermometer before you can take a reading.
 		KerbinSrfLandedR&DObservatory = You observe the temperature.  How fitting.
 		KerbinSrfLandedR&DSideLab = The temperature here is elevated due to the non-stop firing of neurons in this space.
 		KerbinSrfLandedR&DSmallLab = The size of the lab has no effect whatsoever on the temperature readings, contrary to your hypothesis.

--- a/planets/kerbin/mountains/barometerScan.cfg
+++ b/planets/kerbin/mountains/barometerScan.cfg
@@ -13,7 +13,7 @@
 
 		KerbinSrfLandedMountains = The barometer reads very high here.  You aren't surprised as the mountaintop nearly pierces the clouds.
 		KerbinSrfLandedMountains = You stand on your tiptoes and try to insert the barometer into a passing cloud. So close...
-		KerbinFlyingLow = The barometer shakes and shimmies so much in the atmospere that you are unable to get an accurate reading.
+		KerbinFlyingLow = The barometer shakes and shimmies so much in the atmosphere that you are unable to get an accurate reading.
 		KerbinFlyingLow = The air pressure is dropping precipitously. Much like that goat that just fell off the mountain.
 		KerbinFlyingHigh = In the thin, wispy layers of the upper atmosphere a barometer reading is not particularly useful.  You take the reading anyway and send it back to KSC.
 		KerbinFlyingHigh = The barometer data you transmit back to KSC barely qualifies as a proper reading.

--- a/planets/kerbin/mountains/crewReport.cfg
+++ b/planets/kerbin/mountains/crewReport.cfg
@@ -23,7 +23,7 @@
 		KerbinFlyingHigh = Even from up here, Kerbin's mountains remain an imposing sight.
 		KerbinInSpaceLow = You peer down at the mountains below, wondering if there is anyone down there looking up at you.
 		KerbinInSpaceLow = You tell Mission Control that some of those mountains seem perfectly suited for an observatory.
-		KerbinInSpaceHigh = You can barely make out the ridges of Kerbins mountains from this altitude, but enjoy a few snacks with the view.
+		KerbinInSpaceHigh = You can barely make out the ridges of Kerbin's mountains from this altitude, but enjoy a few snacks with the view.
 		KerbinInSpaceHigh = From this distance, Kerbin's mountain ranges blend into one big blob.
 		//LAST_ENTRY
 	}

--- a/planets/kerbin/mountains/mobileMaterialsLab.cfg
+++ b/planets/kerbin/mountains/mobileMaterialsLab.cfg
@@ -14,7 +14,7 @@
 		//KerbinInSpaceHigh = Your science report text here.
 
 		KerbinSrfLandedMountains = The lab slowly rocks back and forth as you perform your experiments perched on top of a particularly craggy mountain.
-		KerbinSrfLandedMountains = You're quite certain that lugging around an entire materials lab while on top of a mountain is as dangeous as it is unnecessary. But hey, you're just an astronaut.
+		KerbinSrfLandedMountains = You're quite certain that lugging around an entire materials lab while on top of a mountain is as dangerous as it is unnecessary. But hey, you're just an astronaut.
 		KerbinFlyingLow = You hope the autopilot is up-to-snuff as you write your lab report while your craft zips past several mountain peaks.
 		KerbinFlyingLow = You are so distracted by the thought of one of the craggy peaks below scraping up against the lab that you're unable to finish the assay.
 		KerbinFlyingHigh = You perform your experiments as you fly high over Kerbin's mountains. Oh look! Is that a yeti?

--- a/planets/kerbin/mountains/temperatureScan.cfg
+++ b/planets/kerbin/mountains/temperatureScan.cfg
@@ -14,7 +14,7 @@
 
 		KerbinSrfLandedMountains = The temperature reports a chilly -15 degrees. You are glad to be inside your nice warm spaceship.  With snacks!
 		KerbinSrfLandedMountains = It's cold sure, but the windchill is even worse! You hope it doesn't blow you off the mountain.
-		KerbinFlyingLowMountains = It's cold, ok.  Just look where you're going, and PLEASE don't turn off the SAS again.
+		KerbinFlyingLowMountains = It's cold, OK.  Just look where you're going, and PLEASE don't turn off the SAS again.
 		KerbinFlyingLowMountains = You're too busy dodging sudden mountains to pay attention to your latest temperature scan.
 		KerbinFlyingHigh = It is chilly up here in the thin wisps of the upper atmosphere.  You report this to KSC, and they laugh back something about being happy they aren't in your shoes.
 		KerbinFlyingHigh = Glancing back and forth between the mountains beneath you and the thermometer display, you realize that you are stuck between a rock and a cold place.

--- a/planets/kerbin/tundra/mobileMaterialsLab.cfg
+++ b/planets/kerbin/tundra/mobileMaterialsLab.cfg
@@ -16,7 +16,7 @@
 		KerbinSrfLandedTundra = The samples inside your lab have devolved into a hunter-gatherer state as a response to the harsh conditions of the Tundra.
 		KerbinSrfLandedTundra = The lab seems small and cramped here. You quickly finish your report and get some fresh air.
 		KerbinFlyingLow = As you open the materials bay, snow rapidly accumulates inside, making it difficult to perform your experiments. 
-		KerbinFlyingLow = The materials seem to have shrunk in their containers, which makes completing your research diffiult.  Hey, we're getting hazard pay for this, right?
+		KerbinFlyingLow = The materials seem to have shrunk in their containers, which makes completing your research difficult.  Hey, we're getting hazard pay for this, right?
 		KerbinFlyingHigh = In your lab report, you include a note asking Mission Control to send you someplace warmer next time.
 		KerbinFlyingHigh = With all the experiments well underway you grab a box of snacks, wishing it was bigger than it is.
 		KerbinInSpaceLow = Low-gravity experiments in space over Kerbin's Tundra. Just another day for a kerbonaut.

--- a/planets/kerbin/tundra/mysteryGoo.cfg
+++ b/planets/kerbin/tundra/mysteryGoo.cfg
@@ -20,7 +20,7 @@
 		KerbinFlyingHigh = The Goo seems to be shrinking away from the sight of the landscape below.  You don't know if this is normal, or if you should be feeding it more snacks.
 		KerbinFlyingHigh = The Goo is...definitely doing something. You scribble something to that effect in your report, serene in the knowledge that you're not the one who has to read it.
 		KerbinInSpaceLow = The Goo immediately stops what it's doing when you peek inside the canister. Very suspicious.
-		KerbinInSpaceLow = The Goo seems to be cavitating at 33.47652 mhz. Strange. You wonder what that means.
+		KerbinInSpaceLow = The Goo seems to be cavitating at 33.47652 MHz. Strange. You wonder what that means.
 		KerbinInSpaceHigh = You let the Goo out. It seems to like space as much as you do. Maybe it wants to grow up to be an astronaut.
 		KerbinInSpaceHigh = After having yet another box of snacks you decide to check on the Goo and find it spilled all over the floor.  See, this is why we can't have nice things.
 		//LAST_ENTRY

--- a/planets/kerbin/water/barometerScan.cfg
+++ b/planets/kerbin/water/barometerScan.cfg
@@ -19,7 +19,7 @@
 		KerbinFlyingLow = Drops of saltwater seem to have encrusted the barometer and you are unable to get an accurate reading. You make something up randomly, and send it back to KSC.
 		KerbinFlyingLow = As you write down the air pressure data you are briefly reminded of your elementary science lessons about 'The Water Cycle'. 
 		KerbinFlyingHigh = The barometer reading isn't very interesting so you look out the window and watch the waves instead.
-		KerbinFlyingHigh = The barometer here seems nominal.  What's not nominal is the anount of snacks we haven't eaten yet.  You radio KSC about this issue.
+		KerbinFlyingHigh = The barometer here seems nominal.  What's not nominal is the amount of snacks we haven't eaten yet.  You radio KSC about this issue.
 		//LAST_ENTRY
 	}
 }

--- a/planets/kerbin/water/crewReport.cfg
+++ b/planets/kerbin/water/crewReport.cfg
@@ -28,7 +28,7 @@
 		KerbinFlyingLowWater = The water looks so peaceful from here.
 		KerbinFlyingLowWater = You imagine all the wonderful creatures that live below the surface that would probably eat you. Or at least brush up against your leg while swimming.
 		KerbinFlyingHigh = What's that big shadow? Is that...a kraken?
-		KerbinFlyingHigh = You look down over the vast ocean below and wonder how many glasses it woould take to empty all that water.
+		KerbinFlyingHigh = You look down over the vast ocean below and wonder how many glasses it would take to empty all that water.
 		KerbinInSpaceLow = From here Kerbin looks like a smooth blue marble.  You never were good at that game.
 		KerbinInSpaceLow = As you watch the great blue seas of Kerbin pass by you wonder what lays hidden in the depths. 
 		KerbinInSpaceHigh = Wow, that ocean really is big.  You're glad you aren't trying to sail across it.

--- a/planets/kerbin/water/evaReport.cfg
+++ b/planets/kerbin/water/evaReport.cfg
@@ -14,7 +14,7 @@
 		//KerbinInSpaceLowWater = Your science report text here.
 		//KerbinInSpaceHigh = Your science report text here.
 
-		KerbinSrfLandedWater = You have trouble swimming because your helmet is more bouyant than the rest of your spacesuit.
+		KerbinSrfLandedWater = You have trouble swimming because your helmet is more buoyant than the rest of your spacesuit.
 		KerbinSrfLandedWater = You wonder if a shark can bite through your spacesuit. You try it yourself and fail. You hope that shark teeth aren't any sharper than yours.
 		KerbinSrfLandedWater = You hope they made this spacesuit waterproof as well as space-proof.
 		KerbinSrfSplashedWater = You calculate the number of snacks you should bring to be able to swim to KSP.

--- a/planets/kerbin/water/gravityScan.cfg
+++ b/planets/kerbin/water/gravityScan.cfg
@@ -12,7 +12,7 @@
 		//KerbinInSpaceLowWater = Your science report text here.
 		//KerbinInSpaceHighWater = Your science report text here.
 
-		KerbinSrfLandedWater = The graviolis aren't too sure about thhis wet stuff, but they report that everything else seems in order.
+		KerbinSrfLandedWater = The graviolis aren't too sure about this wet stuff, but they report that everything else seems in order.
 		KerbinSrfLandedWater = The graviolis are soaking wet, but they report nominal gravity.
 		KerbinSrfSplashedWater = The gravity scan detects disturbances seemingly originating from far underneath the ocean's surface...
 		KerbinSrfSplashedWater = The sensor has detected changes in the local gravity that seem to be related to the passing of the Mun.

--- a/planets/kerbin/water/mobileMaterialsLab.cfg
+++ b/planets/kerbin/water/mobileMaterialsLab.cfg
@@ -25,7 +25,7 @@
 		KerbinInSpaceLow = The view from the lab is particularly distracting today, and you find it takes an extra hour to complete your report.
 		KerbinInSpaceLow = Some of your samples create interesting refractions as they are exposed to the sunlight reflecting from the blue waters of Kerbin.
 		KerbinInSpaceHigh = As you write down your lab report you visually confirm that Kerbin's oceans do indeed make up the majority of its surface.
-		KerbinInSpaceHigh = The lab shimmers blue in the reflected light from Kerbins ocean below.  Or maybe you're just delerious from lack of snacks.
+		KerbinInSpaceHigh = The lab shimmers blue in the reflected light from Kerbin's ocean below.  Or maybe you're just delirious from lack of snacks.
 		//LAST_ENTRY
 	}
 }

--- a/planets/kerbin/water/temperatureScan.cfg
+++ b/planets/kerbin/water/temperatureScan.cfg
@@ -17,7 +17,7 @@
 		KerbinSrfLandedWater = The salty water has encrusted the thermometer and you are unable to get an accurate reading.  So you make something up.
 		KerbinSrfSplashedWater = The water is colder than the surrounding air.
 		KerbinSrfSplashedWater = You have to stick your head underwater in order to see what the thermometer says.
-		KerbinFlyingLowWater = The air seems to be cooled by the water, and the temeprature is lower that average here.
+		KerbinFlyingLowWater = The air seems to be cooled by the water, and the temperature is lower that average here.
 		KerbinFlyingLowWater = You keep an eye out for sudden tsunamis as the thermometer takes its reading of the surrounding air.
 		KerbinFlyingHigh = It appears to be the perfect snack-eating temperature.  You open a box just to be sure.  For science.
 		KerbinFlyingHigh = Sitting inside your climate-controlled cockpit, you find that you don't really care what the thermometer thinks of the outside temperature. 

--- a/planets/laythe/default/evaReport.cfg
+++ b/planets/laythe/default/evaReport.cfg
@@ -25,7 +25,7 @@
 		LaytheSrfSplashed = You tread water. Perhaps you should have chosen a drier landing spot.
 		LaytheSrfSplashed = Swimming is really hard in these suits you know.
 		LaytheFlyingLow = Now I really wish I had brought that parachute.
-		LaytheFlyingHigh = As you repair one of the heat shielding tiles that fell off, you are reminded of your first return through Kerbins' atmosphere.
+		LaytheFlyingHigh = As you repair one of the heat shielding tiles that fell off, you are reminded of your first return through Kerbin's' atmosphere.
 		LaytheInSpaceLow = As you gaze down upon the flowing waters of Laythe, you discover that you need a toilet.
 		LaytheInSpaceHigh = You almost feel like you are floating above Kerbin.
 		//LAST_ENTRY

--- a/planets/laythe/default/surfaceSample.cfg
+++ b/planets/laythe/default/surfaceSample.cfg
@@ -15,7 +15,7 @@
 		LaytheSrfLanded = Small pebbles you've found look to be shaped by water.
 		LaytheSrfLanded = The soil contains a lot of silica and feels very rough.
 		LaytheSrfLanded = You try to form a castle out of the soil. For science, of course.
-		LaytheSrfLanded = The soil here contains some ore's that looks like cronstedtite.
+		LaytheSrfLanded = The soil here contains some ores that looks like cronstedtite.
 		LaytheSrfSplashed = The liquid filling these basins seems to be different than Kerbin's.
 		LaytheSrfSplashed = The sample sticks to your suit. You wonder if Mission Control is going to charge you for the dry cleaning.
 		LaytheSrfSplashed = The liquid, though definitely water, contains impurities that seem to help it maintain a liquid state at these temperatures.

--- a/planets/laythe/poles/gravityScan.cfg
+++ b/planets/laythe/poles/gravityScan.cfg
@@ -13,7 +13,7 @@
 		
 		LaytheSrfLandedPoles = You notice the gravity scans have been saying 666 over and over again.
 		LaytheSrfLandedPoles = Shaking the scanner does not seem to budge it. Instead you get out a golf ball and club. Gravity must be weaker than on Kerbin because you just hit it far enough for a hole in one!
-		LaytheInSpaceLowPoles = Your scanner shows that the gravitational draw of this moon does not change whereever you go. The water makes the planet smoother than a baby Kerbal's bottom.
+		LaytheInSpaceLowPoles = Your scanner shows that the gravitational draw of this moon does not change wherever you go. The water makes the planet smoother than a baby Kerbal's bottom.
 		//LAST_ENTRY
 	}
 }

--- a/planets/laythe/poles/mysteryGoo.cfg
+++ b/planets/laythe/poles/mysteryGoo.cfg
@@ -14,7 +14,7 @@
 		//LaytheInSpaceHigh = Your science report text here.
 		LaytheSrfLandedPoles = The Goo seems excited. Perhaps it wants to swim in the ocean?
 		LaytheFlyingLow = You note that the mystery goo Containment Unit is wobbling a little. Is that the Goo? Or is it just the screws coming loose?
-		LaytheFlyingHigh = There does not seem to be much activity coming from the Containment Unit. Only close exaimination reveals a slight pulsing.
+		LaytheFlyingHigh = There does not seem to be much activity coming from the Containment Unit. Only close examination reveals a slight pulsing.
 		LaytheInSpaceLow = The Goo seems right at home in space.
 		//LAST_ENTRY
 	}

--- a/planets/minmus/poles/temperatureScan.cfg
+++ b/planets/minmus/poles/temperatureScan.cfg
@@ -9,6 +9,6 @@
 		// entry just before '//LAST_ENTRY' or with similar entries.
 		//MinmusSrfLandedPoles = Your science report text here.
 		//MinmusInSpaceLow = Your science report text here.
-		//LAS_ENTRY
+		//LAST_ENTRY
 	}
 }

--- a/planets/mun/default/crewReport.cfg
+++ b/planets/mun/default/crewReport.cfg
@@ -12,7 +12,7 @@
 		//MunInSpaceHigh = Your science report text here.	
 		
 		MunSrfLanded = You feel awestruck at the beaten up nature of the Mun.
-		MunInSpaceLow = You glance by your window at the surfa... Whoa! Who put mountains this high on a rock this small?!
+		MunInSpaceLow = You glance out your window at the surface... Whoa! Who put mountains this high on a rock this small?!
 		MunInSpaceLow = Your ships suffers a minor depressurization, but quick thinking and lots of bubble gum manage to solve the problem before it gets out of hand.
 		MunInSpaceLow = Looking down at the Mun's surface, you suddenly feel tempted to eat cheese.
 		MunInSpaceLow = "Crew reporting in. We are currently near the Mun. It turns out it's much bigger than we thought it was."

--- a/planets/mun/default/surfaceSample.cfg
+++ b/planets/mun/default/surfaceSample.cfg
@@ -13,7 +13,7 @@
 		MunSrfLanded = You take a sample and confirm that the Mun is not made of cheese.
 		MunSrfLanded = Wensleydale? Stilton? It isn't like any cheese you've tasted. You wonder if its actually cheese at all.
 		MunSrfLanded = You suddenly realize why the physical examination screened for breathing problems.
-		MunSrfLanded = Oddly enough, the sample smells similar to swiss cheese. One wonders if it's edible.
+		MunSrfLanded = Oddly enough, the sample smells similar to Swiss cheese. One wonders if it's edible.
 		MunSrfLanded = The dust seems to be ionized due to long-term exposure to sunlight without an atmosphere to filter it. It sticks to your suit.
 		MunSrfLanded = Unfortunately, it's not cheese. You double-check it, but it still isn't.
 		MunSrfLanded = You note the sample's lack of cheese.

--- a/planets/mun/east crater/USI_SR.cfg
+++ b/planets/mun/east crater/USI_SR.cfg
@@ -57,7 +57,7 @@
 		//MunInSpaceLowEastCrater = Your science report text here.
 		//MunInSpaceHighEastCrater = Your science report text here.
 
-		MunSrfLandedEastCrater = The materials are covered in a fine film of dust from the mun's surface.
+		MunSrfLandedEastCrater = The materials are covered in a fine film of dust from the Mun's surface.
 		MunInSpaceLowEastCrater = The experiment reveals slight distortions caused by the solar radiation on the trip here.
 		MunInSpaceHighEastCrater = The experiment is highly uninformative. But hey, at least it was cheap!
 		//LAST_ENTRY
@@ -79,7 +79,7 @@
 
 		MunSrfLandedEastCrater = The engineers are glad they sent an experiment, rather than getting covered in dust themselves.
 		MunInSpaceLowEastCrater = The engineering analysis of the East Crater reveals that it is nearly identical to the Western Crater.
-		MunInSpaceHighEastCrater = The experiment doesn't return much useul data from this altitude.
+		MunInSpaceHighEastCrater = The experiment doesn't return much useful data from this altitude.
 		//LAST_ENTRY
 	}
 }

--- a/planets/mun/east crater/temperatureScan.cfg
+++ b/planets/mun/east crater/temperatureScan.cfg
@@ -12,7 +12,7 @@
 
 		MunInSpaceLow = The temperature here is wholly uninteresting compared to the box of snacks in your hand.
 		MunInSpaceLow = You read the thermal data and sadly put away your flip-flops.
-		MunSrfLandedEastCrater = The temperature flutuates wildly with the rotation of the moon, as the crater moves from day to night.
+		MunSrfLandedEastCrater = The temperature fluctuates wildly with the rotation of the moon, as the crater moves from day to night.
 		//LAST_ENTRY
 	}
 }

--- a/planets/mun/east farside crater/USI_SR.cfg
+++ b/planets/mun/east farside crater/USI_SR.cfg
@@ -38,7 +38,7 @@
 		//MunInSpaceHighEastFarsideCrater = Your science report text here.
 
 		MunSrfLandedEastFarsideCrater = Even here on the surface the experiment reveals no atmosphere.
-		MunInSpaceLowEastFarsideCrater = The scientists back at KSC are dissapointed that the results don't indicate the presence of an atmosphere on the surface below.
+		MunInSpaceLowEastFarsideCrater = The scientists back at KSC are disappointed that the results don't indicate the presence of an atmosphere on the surface below.
 		MunInSpaceHighEastFarsideCrater = You have to agree, this data is much better than throwing a dart at a dartboard.
 		//LAST_ENTRY
 	}

--- a/planets/mun/east farside crater/gravityScan.cfg
+++ b/planets/mun/east farside crater/gravityScan.cfg
@@ -12,7 +12,7 @@
 		//MunInSpaceHighEastFarsideCrater = Your science report text here.
 		
 		MunSrfLandedEastFarsideCrater = The graviolis are having fun bouncing off the crater walls.
-		MunInSpaceLowEastFarsideCrater = The gravity fluctuates slighty - but noticeably - as you pass over the crater below.
+		MunInSpaceLowEastFarsideCrater = The gravity fluctuates slightly - but noticeably - as you pass over the crater below.
 		MunInSpaceLowEastFarsideCrater = You try to convince the graviolis that this is indeed an entirely new crater and not at all the same as the last one.
 		MunInSpaceHighEastFarsideCrater = You wonder what sorts of questions this data will answer back at KSC. Other than "What is the gravity like above the Mun's East Farside Crater?"
 		MunInSpaceHighEastFarsideCrater = There might be a slight gravitational anomaly here.  Or you might just be seeing things and be in dire need of a snack.

--- a/planets/mun/east farside crater/mobileMaterialsLab.cfg
+++ b/planets/mun/east farside crater/mobileMaterialsLab.cfg
@@ -11,7 +11,7 @@
 		//MunInSpaceLow = Your science report text here.
 		//MunInSpaceHigh = Your science report text here.
 		
-		MunSrfLandedEastFarsideCrater = The materials promptly roll down the hill to the lowest part of the crater as soon as you open the canister.  You guess thats why its a 'Mobile Materials' Lab.
+		MunSrfLandedEastFarsideCrater = The materials promptly roll down the hill to the lowest part of the crater as soon as you open the canister.  You guess that's why its a 'Mobile Materials' Lab.
 		MunInSpaceLow = You are too busy doodling the crater below to finish your lab experiments, so you send the doodle back to KSC instead of your report..
 		MunInSpaceLow = After much deliberation, the samples have all agreed that the Mun does not in fact appear to be made of cheese. You proudly send this report back up to KSC.
 		MunInSpaceHigh = You fill your lab report with scribbled images of you planting a flag on the Mun (not to scale). You hope the folks back at KSC get the hint.

--- a/planets/mun/highland craters/mobileMaterialsLab.cfg
+++ b/planets/mun/highland craters/mobileMaterialsLab.cfg
@@ -11,7 +11,7 @@
 		//MunInSpaceLow = Your science report text here.
 		//MunInSpaceHigh = Your science report text here.
 
-		MunSrfLandedHighlandCraters = As you complete your lab reports you look forward to EVA'ing and running down the slope of the crater to see how fast you can get going.		
+		MunSrfLandedHighlandCraters = As you complete your lab reports you look forward to EVA-ing and running down the slope of the crater to see how fast you can get going.		
 		MunInSpaceLow = The materials lab is ready for action! You, however, need a snack first to get you going.
 		MunInSpaceHigh = It's getting very difficult to keep track of your experiments as they float around in the low gravity. Maybe you shouldn't have tried to them all at once.
 		//LAST_ENTRY

--- a/planets/mun/poles/gravityScan.cfg
+++ b/planets/mun/poles/gravityScan.cfg
@@ -11,7 +11,7 @@
 		//MunInSpaceLowPoles = Your science report text here.
 		//MunInSpaceHighPoles = Your science report text here.
 
-		//MunSrfLandedPoles = The graviolis arent sure whether this is the north or south pole, so they just flow 'down.'		
+		//MunSrfLandedPoles = The graviolis aren't sure whether this is the north or south pole, so they just flow 'down.'		
 		MunInSpaceLowPoles = The gravity scanner spits out an impressively long sheet of paper. To your dismay, it's almost entirely filled with numbers.
 		MunInSpaceHighPoles = Polar measurement of the Mun's gravitational field? Check! Time for a snack.
 		//LAST_ENTRY

--- a/planets/mun/poles/surfaceSample.cfg
+++ b/planets/mun/poles/surfaceSample.cfg
@@ -11,7 +11,7 @@
 		
 		MunSrfLandedPoles = You wonder if this would make a nice snack.
 		MunSrfLandedPoles = It's a cold piece of soil. As cold as ice. Wait.
-		MunSrfLandedPoles = You examine the rocks you have collected. Upon further investigation, you realise that there is a strange weight to one of them, it does not feel like it has the same weight as the other rocks you’ve collected and seems hollow. You promptly place it into a sample container.
+		MunSrfLandedPoles = You examine the rocks you have collected. Upon further investigation, you realise that there is a strange weight to one of them, it does not feel like it has the same weight as the other rocks you've collected and seems hollow. You promptly place it into a sample container.
 		MunSrfLandedPoles = The samples here show lower concentrations of ejecta. There appears to be some liquids in the soil that have frozen permanently.
 		//LAST_ENTRY
 	}

--- a/planets/sun/default/mobileMaterialsLab.cfg
+++ b/planets/sun/default/mobileMaterialsLab.cfg
@@ -20,7 +20,7 @@
 		SunInSpaceLow = Some of the material samples have started to glow from the intense radiation.
 		SunInSpaceLow = The samples appear to be sweating.
 		SunInSpaceLow = The red hot glow of the metallic samples rivals the blazing intensity of the sun.
-		SunInSpaceLow = It says here "directly expose to sun for five minutes for a brillant golden colour."
+		SunInSpaceLow = It says here "directly expose to sun for five minutes for a brilliant golden colour."
 		SunInSpaceLow = The materials in the lab very clearly want to be farther away from the sun.
 		SunInSpaceHigh = The rocks show little signs of change. Some phosphorous samples glow a bright blue color, indicating the high radiation of interplanetary space.
 		SunInSpaceHigh = The materials, now exposed directly to the sun, are decidedly uncomfortable.


### PR DESCRIPTION
I got annoyed about seeing a typo in a science report from the crawlerway, so ran a spell checker over all of the reports. I've also made a few changes like capitalising planet names throughout and fixing some of the more obvious grammar errors.

I tried to avoid changing US to international spelling or vice-versa. But where I wasn't sure what the author's intention was I used my native Australian version. Fairly sure I didn't change anything that would break a joke, but would appreciate extra eyes on that.

There's still some weird grammar and capitalisation that I'd like to fix up, but I think this takes care of the most glaring errors.