### PR TITLE
Squad no longer restricts the barometer to atmospheres only

### DIFF
--- a/temp/BarometerTweaks.cfg
+++ b/temp/BarometerTweaks.cfg
@@ -5,9 +5,6 @@
 
 @EXPERIMENT_DEFINITION[*]:HAS[#id[barometerScan]]
 {
-	@requireAtmosphere = False
-	@situationMask = 31
-	
 	%RESULTS
 	{
 		SunInSpaceLow = Despite the proximity of the giant glowing ball of plasma below you, the needle refuses to budge. I guess I need to get a little closer...


### PR DESCRIPTION
So we can delete those patches from the top.