### PR TITLE
Fix typo in Kerbin / KSC / mobileMaterialsLab.cfg

### DIFF
--- a/planets/kerbin/ksc/mobileMaterialsLab.cfg
+++ b/planets/kerbin/ksc/mobileMaterialsLab.cfg
@@ -22,7 +22,7 @@
 		KerbinSrfLandedFlagPole = The materials seem unimpressed by your climbing skills. 
 		KerbinSrfLandedLaunchPad = You think that this experiment is rather superfluous.
 		KerbinSrfLandedLaunchPad = The materials are neatly arranged, waiting for launch. You suppress the urge to shake the container. 
-		KerbinSrfLandedMissionControl =  Mission control wonders why you have do do your experiment HERE. 
+		KerbinSrfLandedMissionControl =  Mission control wonders why you have to do your experiment HERE. 
 		KerbinSrfLandedRunway = The materials are all facing upwards. You hastily turn them sideways. 
 		KerbinSrfLandedSPH = The great view of the new planes distracts you from getting any meaningful lab work done.
 		KerbinSrfLandedSPHMainBuilding = The engineers here eye your lab module with disdain.


### PR DESCRIPTION
Fixed typo in Mission Control's Science Jr report.