### PR TITLE
Fix removing "default" results 

### DIFF
--- a/Source/ScienceFixer.cs
+++ b/Source/ScienceFixer.cs
@@ -28,6 +28,8 @@ namespace ScienceFixer
                 {
                     if (!key.name.StartsWith("default") && !key.name.EndsWith("*"))
                         data.AddValue(key.name + "*", key.value);
+                    else
+                        data.AddValue(key.name, key.value);
                 }
                 results.ClearData();
                 results.AddData(data);


### PR DESCRIPTION
This pull request retains existing "default" results or those already ending in asterisk (*) defined in mods.

Verified to fix #56.